### PR TITLE
Corrected obs_temp_comp_gain variable in adi/ad9371.py

### DIFF
--- a/adi/ad9371.py
+++ b/adi/ad9371.py
@@ -289,7 +289,7 @@ class ad9371(rx_tx, context_manager):
             self._set_iio_attr("voltage2", "hardwaregain", False, value)
 
     @property
-    def obs_temp_comp_gain0(self):
+    def obs_temp_comp_gain(self):
         """obs_temp_comp_gain: """
         return self._get_iio_attr("voltage2", "temp_comp_gain", False)
 

--- a/test/test_ad9371.py
+++ b/test/test_ad9371.py
@@ -1,10 +1,12 @@
-import pytest
-
-import adi
+import heapq
 import test.rf.spec as spec
 import time
+from os import listdir
+from os.path import dirname, join, realpath
+
+import adi
 import numpy as np
-import heapq
+import pytest
 from scipy import signal
 
 hardware = "ad9371"
@@ -13,8 +15,8 @@ classname = "adi.ad9371"
 profile_path = dirname(realpath(__file__)) + "/ad9371_5_profiles/"
 test_profiles = [join(profile_path, f) for f in listdir(profile_path)]
 
-params = [
-    dict(   # One CW Tone, Manual
+params = dict(
+    one_cw_tone_manual=dict(
         ensm_mode="radio_on",
         tx_lo=2500000000,
         rx_lo=2500000000,
@@ -30,7 +32,7 @@ params = [
         tx_quadrature_tracking_en_chan0=1,
         tx_quadrature_tracking_en_chan1=1,
     ),
-    dict(   # One CW Tone, Automatic
+    one_cw_tone_auto=dict(
         ensm_mode="radio_on",
         tx_lo=2500000000,
         rx_lo=2500000000,
@@ -44,83 +46,7 @@ params = [
         tx_quadrature_tracking_en_chan0=1,
         tx_quadrature_tracking_en_chan1=1,
     ),
-    dict(   # Change frequency up/down, Automatic, 2MHz
-        ensm_mode="radio_on",
-        tx_lo=2500000000,
-        rx_lo=2500000000,
-        gain_control_mode="automatic",
-        rx_quadrature_tracking_en_chan0=1,
-        rx_quadrature_tracking_en_chan1=1,
-        rx_temp_comp_gain_chan0=0,
-        rx_temp_comp_gain_chan1=0,
-        tx_hardwaregain_chan0=-10,
-        tx_hardwaregain_chan1=-10,
-        tx_quadrature_tracking_en_chan0=1,
-        tx_quadrature_tracking_en_chan1=1,
-    ),
-    dict(   # Change frequency up/down, Automatic, 0.5MHz
-        ensm_mode="radio_on",
-        tx_lo=2500000000,
-        rx_lo=2500000000,
-        gain_control_mode="automatic",
-        rx_quadrature_tracking_en_chan0=1,
-        rx_quadrature_tracking_en_chan1=1,
-        rx_temp_comp_gain_chan0=0,
-        rx_temp_comp_gain_chan1=0,
-        tx_hardwaregain_chan0=-10,
-        tx_hardwaregain_chan1=-10,
-        tx_quadrature_tracking_en_chan0=1,
-        tx_quadrature_tracking_en_chan1=1,
-    ),
-    dict(   # Change scale up/down, Manual, -6dB
-        ensm_mode="radio_on",
-        tx_lo=2500000000,
-        rx_lo=2500000000,
-        gain_control_mode="manual",
-        rx_hardwaregain_chan0=10,
-        rx_hardwaregain_chan1=10,
-        rx_quadrature_tracking_en_chan0=1,
-        rx_quadrature_tracking_en_chan1=1,
-        rx_temp_comp_gain_chan0=0,
-        rx_temp_comp_gain_chan1=0,
-        tx_hardwaregain_chan0=0,
-        tx_hardwaregain_chan1=0,
-        tx_quadrature_tracking_en_chan0=1,
-        tx_quadrature_tracking_en_chan1=1,
-    ),
-    dict(   # Change scale up/down, Manual, -18dB
-        ensm_mode="radio_on",
-        tx_lo=2500000000,
-        rx_lo=2500000000,
-        gain_control_mode="manual",
-        rx_hardwaregain_chan0=10,
-        rx_hardwaregain_chan1=10,
-        rx_quadrature_tracking_en_chan0=1,
-        rx_quadrature_tracking_en_chan1=1,
-        rx_temp_comp_gain_chan0=0,
-        rx_temp_comp_gain_chan1=0,
-        tx_hardwaregain_chan0=0,
-        tx_hardwaregain_chan1=0,
-        tx_quadrature_tracking_en_chan0=1,
-        tx_quadrature_tracking_en_chan1=1,
-    ),
-    dict(   # Change attenuation up/down, Manual, 10dB
-        ensm_mode="radio_on",
-        tx_lo=2500000000,
-        rx_lo=2500000000,
-        gain_control_mode="manual",
-        rx_hardwaregain_chan0=10,
-        rx_hardwaregain_chan1=10,
-        rx_quadrature_tracking_en_chan0=1,
-        rx_quadrature_tracking_en_chan1=1,
-        rx_temp_comp_gain_chan0=0,
-        rx_temp_comp_gain_chan1=0,
-        tx_hardwaregain_chan0=-10,
-        tx_hardwaregain_chan1=-10,
-        tx_quadrature_tracking_en_chan0=1,
-        tx_quadrature_tracking_en_chan1=1,
-    ),
-    dict(   # Change attenuation up/down, Manual, 5dB
+    change_attenuation_5dB_manual=dict(
         ensm_mode="radio_on",
         tx_lo=2500000000,
         rx_lo=2500000000,
@@ -136,7 +62,37 @@ params = [
         tx_quadrature_tracking_en_chan0=1,
         tx_quadrature_tracking_en_chan1=1,
     ),
-    dict(   # Change attenuation up/down, Automatic, 20dB
+    change_attenuation_10dB_manual=dict(
+        ensm_mode="radio_on",
+        tx_lo=2500000000,
+        rx_lo=2500000000,
+        gain_control_mode="manual",
+        rx_hardwaregain_chan0=10,
+        rx_hardwaregain_chan1=10,
+        rx_quadrature_tracking_en_chan0=1,
+        rx_quadrature_tracking_en_chan1=1,
+        rx_temp_comp_gain_chan0=0,
+        rx_temp_comp_gain_chan1=0,
+        tx_hardwaregain_chan0=-10,
+        tx_hardwaregain_chan1=-10,
+        tx_quadrature_tracking_en_chan0=1,
+        tx_quadrature_tracking_en_chan1=1,
+    ),
+    change_attenuation_0dB_auto=dict(
+        ensm_mode="radio_on",
+        tx_lo=2500000000,
+        rx_lo=2500000000,
+        gain_control_mode="automatic",
+        rx_quadrature_tracking_en_chan0=1,
+        rx_quadrature_tracking_en_chan1=1,
+        rx_temp_comp_gain_chan0=0,
+        rx_temp_comp_gain_chan1=0,
+        tx_hardwaregain_chan0=0,
+        tx_hardwaregain_chan1=0,
+        tx_quadrature_tracking_en_chan0=1,
+        tx_quadrature_tracking_en_chan1=1,
+    ),
+    change_attenuation_20dB_auto=dict(
         ensm_mode="radio_on",
         tx_lo=2500000000,
         rx_lo=2500000000,
@@ -150,38 +106,7 @@ params = [
         tx_quadrature_tracking_en_chan0=1,
         tx_quadrature_tracking_en_chan1=1,
     ),
-    dict(   # Change attenuation up/down, Automatic, 0dB
-        ensm_mode="radio_on",
-        tx_lo=2500000000,
-        rx_lo=2500000000,
-        gain_control_mode="automatic",
-        rx_quadrature_tracking_en_chan0=1,
-        rx_quadrature_tracking_en_chan1=1,
-        rx_temp_comp_gain_chan0=0,
-        rx_temp_comp_gain_chan1=0,
-        tx_hardwaregain_chan0=0,
-        tx_hardwaregain_chan1=0,
-        tx_quadrature_tracking_en_chan0=1,
-        tx_quadrature_tracking_en_chan1=1,
-    ),
-    dict(   # Change rf_gain up/down, Manual, 20dB,
-            # TRX_LO = 1000MHz
-        ensm_mode="radio_on",
-        tx_lo=1000000000,
-        rx_lo=1000000000,
-        gain_control_mode="manual",
-        rx_hardwaregain_chan0=20,
-        rx_hardwaregain_chan1=20,
-        rx_quadrature_tracking_en_chan0=1,
-        rx_quadrature_tracking_en_chan1=1,
-        rx_temp_comp_gain_chan0=0,
-        rx_temp_comp_gain_chan1=0,
-        tx_hardwaregain_chan0=0,
-        tx_hardwaregain_chan1=0,
-        tx_quadrature_tracking_en_chan0=1,
-        tx_quadrature_tracking_en_chan1=1,
-    ),
-    dict(   # Change rf_gain up/down, Manual, 0dB
+    change_rf_gain_0dB_manual=dict(
         ensm_mode="radio_on",
         tx_lo=2500000000,
         rx_lo=2500000000,
@@ -197,7 +122,23 @@ params = [
         tx_quadrature_tracking_en_chan0=1,
         tx_quadrature_tracking_en_chan1=1,
     ),
-    dict(   # Change temp_gain up/down, Manual, 3dB
+    change_rf_gain_20dB_manual=dict(
+        ensm_mode="radio_on",
+        tx_lo=2500000000,
+        rx_lo=2500000000,
+        gain_control_mode="manual",
+        rx_hardwaregain_chan0=20,
+        rx_hardwaregain_chan1=20,
+        rx_quadrature_tracking_en_chan0=1,
+        rx_quadrature_tracking_en_chan1=1,
+        rx_temp_comp_gain_chan0=0,
+        rx_temp_comp_gain_chan1=0,
+        tx_hardwaregain_chan0=0,
+        tx_hardwaregain_chan1=0,
+        tx_quadrature_tracking_en_chan0=1,
+        tx_quadrature_tracking_en_chan1=1,
+    ),
+    change_temp_gain_up=dict(
         ensm_mode="radio_on",
         tx_lo=2500000000,
         rx_lo=2500000000,
@@ -213,7 +154,7 @@ params = [
         tx_quadrature_tracking_en_chan0=1,
         tx_quadrature_tracking_en_chan1=1,
     ),
-    dict(   # Change temp_gain up/down, Manual, -3dB
+    change_temp_gain_down=dict(
         ensm_mode="radio_on",
         tx_lo=2500000000,
         rx_lo=2500000000,
@@ -229,10 +170,10 @@ params = [
         tx_quadrature_tracking_en_chan0=1,
         tx_quadrature_tracking_en_chan1=1,
     ),
-]
+)
 
 params_obs = [
-    dict(   # Obs/Sniffer Manual Profile
+    dict(  # Obs/Sniffer Manual Profile
         ensm_mode="radio_on",
         tx_hardwaregain_chan0=0,
         tx_hardwaregain_chan1=0,
@@ -282,21 +223,36 @@ def test_ad9371_rx_data(test_dma_rx, iio_uri, classname, channel):
 @pytest.mark.parametrize(
     "param_set, frequency, scale, peak_min",
     [
-        (params[0], 2000000, 0.25, -19),
-        (params[1], 1000000, 0.12, -14.7),
-        (params[2], 2000000, 0.12, -14.7),
-        (params[3], 500000, 0.12, -14.7),
-        (params[4], 2000000, 0.5, -13),
-        (params[5], 2000000, 0.12, -25,),
-        (params[6], 2000000, 0.25, -28.75),
-        (params[7], 2000000, 0.25, -23.8),
-        (params[8], 1000000, 0.12, -24.7),
-        (params[9], 1000000, 0.12, -9),
-        (params[10], 2000000, 0.25, -9),
-        (params[11], 2000000, 0.25, -29),
-        (params[12], 2000000, 0.25, -16),
-        (params[13], 2000000, 0.25, -22),
-    ]
+        (params["one_cw_tone_manual"], 2000000, 0.5, -13),
+        (params["one_cw_tone_manual"], 2000000, 0.12, -25),
+        (params["one_cw_tone_manual"], 2000000, 0.25, -19),
+        (params["one_cw_tone_auto"], 1000000, 0.12, -14.7),
+        (params["one_cw_tone_auto"], 2000000, 0.12, -14.7),
+        (params["one_cw_tone_auto"], 500000, 0.12, -14.7),
+        (params["change_attenuation_5dB_manual"], 2000000, 0.25, -23.8),
+        (params["change_attenuation_10dB_manual"], 2000000, 0.25, -28.75),
+        (params["change_attenuation_0dB_auto"], 1000000, 0.12, -9),
+        (params["change_attenuation_20dB_auto"], 1000000, 0.12, -24.7),
+        (params["change_rf_gain_0dB_manual"], 2000000, 0.25, -29),
+        (params["change_rf_gain_20dB_manual"], 2000000, 0.25, -9),
+        (params["change_temp_gain_up"], 2000000, 0.25, -16),
+        (params["change_temp_gain_down"], 2000000, 0.25, -22),
+        # peak_min when the ADRV9371 setup has a splitter between RX and ORX
+        # (params["one_cw_tone_manual"], 2000000, 0.5, -33),
+        # (params["one_cw_tone_manual"], 2000000, 0.12, -45),
+        # (params["one_cw_tone_manual"], 2000000, 0.25, -39),
+        # (params["one_cw_tone_auto"], 1000000, 0.12, -34.7),
+        # (params["one_cw_tone_auto"], 2000000, 0.12, -34.7),
+        # (params["one_cw_tone_auto"], 500000, 0.12, -34.7),
+        # (params["change_attenuation_5dB_manual"], 2000000, 0.25, -43.8),
+        # (params["change_attenuation_10dB_manual"], 2000000, 0.25, -48.75),
+        # (params["change_attenuation_0dB_auto"], 1000000, 0.12, -29),
+        # (params["change_attenuation_20dB_auto"], 1000000, 0.12, -44.7),
+        # (params["change_rf_gain_0dB_manual"], 2000000, 0.25, -49),
+        # (params["change_rf_gain_20dB_manual"], 2000000, 0.25, -29),
+        # (params["change_temp_gain_up"], 2000000, 0.25, -36),
+        # (params["change_temp_gain_down"], 2000000, 0.25, -42),
+    ],
 )
 def test_ad9371_dds_loopback(
     test_dds_loopback,
@@ -319,9 +275,7 @@ def test_ad9371_dds_loopback(
 @pytest.mark.parametrize("channel", [0, 1])
 @pytest.mark.parametrize(
     "param_set, frequency1, scale1, peak_min1, frequency2, scale2, peak_min2",
-    [
-        (params[1], 1000000, 0.06, -21, 2000000, 0.12, -15)
-    ]
+    [(params["one_cw_tone_auto"], 1000000, 0.06, -21, 2000000, 0.12, -15)],
 )
 def test_ad9371_two_tone_loopback(
     iio_uri,
@@ -333,7 +287,7 @@ def test_ad9371_two_tone_loopback(
     peak_min1,
     frequency2,
     scale2,
-    peak_min2
+    peak_min2,
 ):
     # See if we can tone using DMAs
     sdr = eval(classname + "(uri='" + iio_uri + "')")
@@ -363,13 +317,13 @@ def test_ad9371_two_tone_loopback(
     del sdr
     tone_peaks, tone_freqs = spec.spec_est(data, fs=RXFS, ref=2 ** 15)
     indx = heapq.nlargest(2, range(len(tone_peaks)), tone_peaks.__getitem__)
-    print("Peak 1: "
-          + str(tone_peaks[indx[0]]) + " @ " + str(tone_freqs[indx[0]]))
-    print("Peak 2: "
-          + str(tone_peaks[indx[1]]) + " @ " + str(tone_freqs[indx[1]]))
+    print("Peak 1: " + str(tone_peaks[indx[0]]) + " @ " + str(tone_freqs[indx[0]]))
+    print("Peak 2: " + str(tone_peaks[indx[1]]) + " @ " + str(tone_freqs[indx[1]]))
 
     try:
-        if (abs(frequency1 - tone_freqs[indx[0]]) <= (frequency1 * 0.01)) and (abs(frequency2 - tone_freqs[indx[1]]) <= (frequency2 * 0.01)):
+        if (abs(frequency1 - tone_freqs[indx[0]]) <= (frequency1 * 0.01)) and (
+            abs(frequency2 - tone_freqs[indx[1]]) <= (frequency2 * 0.01)
+        ):
             diff1 = np.abs(tone_freqs[indx[0]] - frequency1)
             diff2 = np.abs(tone_freqs[indx[1]] - frequency2)
             # print(frequency1, frequency2)
@@ -380,7 +334,9 @@ def test_ad9371_two_tone_loopback(
             assert (frequency2 * 0.01) > diff2
             assert tone_peaks[indx[0]] > peak_min1
             assert tone_peaks[indx[1]] > peak_min2
-        elif (abs(frequency2 - tone_freqs[indx[0]]) <= (frequency2 * 0.01)) and (abs(frequency1 - tone_freqs[indx[1]]) <= (frequency1 * 0.01)):
+        elif (abs(frequency2 - tone_freqs[indx[0]]) <= (frequency2 * 0.01)) and (
+            abs(frequency1 - tone_freqs[indx[1]]) <= (frequency1 * 0.01)
+        ):
             diff1 = np.abs(tone_freqs[indx[0]] - frequency2)
             diff2 = np.abs(tone_freqs[indx[1]] - frequency1)
             # print(frequency1, frequency2)
@@ -402,19 +358,19 @@ def test_ad9371_two_tone_loopback(
 @pytest.mark.parametrize(
     "param_set, dds_scale, min_rssi, max_rssi",
     [
-        (params[0], 0.25, 14.5, 15.5),
-        (params[1], 0.12, 10.5, 11.5),
-        (params[4], 0.5, 8.5, 9.5),
-        (params[5], 0.12, 20.5, 21.5),
-        (params[6], 0.25, 24.25, 25.25),
-        (params[7], 0.25, 19.5, 20.5),
-        (params[8], 0.12, 20.25, 21.5),
-        (params[9], 0.12, 4.75, 5.75),
-        (params[10], 0.25, 5, 6),
-        (params[11], 0.25, 24.75, 26),
-        (params[12], 0.25, 14.5, 15.5),
-        (params[13], 0.25, 14.5, 15.5),
-    ]
+        (params["one_cw_tone_manual"], 0.5, 8.5, 9.5),
+        (params["one_cw_tone_manual"], 0.12, 20.5, 21.5),
+        (params["one_cw_tone_manual"], 0.25, 14.5, 15.5),
+        (params["one_cw_tone_auto"], 0.12, 10.5, 11.5),
+        (params["change_attenuation_5dB_manual"], 0.25, 19.5, 20.5),
+        (params["change_attenuation_10dB_manual"], 0.25, 24.25, 25.25),
+        (params["change_attenuation_0dB_auto"], 0.12, 4.75, 5.75),
+        (params["change_attenuation_20dB_auto"], 0.12, 20.25, 21.5),
+        (params["change_rf_gain_0dB_manual"], 0.25, 24.75, 26),
+        (params["change_rf_gain_20dB_manual"], 0.25, 5, 6),
+        (params["change_temp_gain_up"], 0.25, 14.5, 15.5),
+        (params["change_temp_gain_down"], 0.25, 14.5, 15.5),
+    ],
 )
 def test_ad9371_dds_gain_check_vary_power(
     test_gain_check,
@@ -438,21 +394,17 @@ def test_ad9371_dds_gain_check_vary_power(
 @pytest.mark.parametrize(
     "param_set",
     [
-        params[0],
-        params[1],
-        params[2],
-        params[3],
-        params[4],
-        params[5],
-        params[6],
-        params[7],
-        params[8],
-        params[9],
-        params[10],
-        params[11],
-        params[12],
-        params[13],
-    ]
+        params["one_cw_tone_manual"],
+        params["one_cw_tone_auto"],
+        params["change_attenuation_5dB_manual"],
+        params["change_attenuation_10dB_manual"],
+        params["change_attenuation_0dB_auto"],
+        params["change_attenuation_20dB_auto"],
+        params["change_rf_gain_0dB_manual"],
+        params["change_rf_gain_20dB_manual"],
+        params["change_temp_gain_up"],
+        params["change_temp_gain_down"],
+    ],
 )
 @pytest.mark.parametrize("sfdr_min", [40])
 def test_ad9371_sfdr(test_sfdr, iio_uri, classname, channel, param_set, sfdr_min):

--- a/test/test_ad9371.py
+++ b/test/test_ad9371.py
@@ -10,6 +10,9 @@ from scipy import signal
 hardware = "ad9371"
 classname = "adi.ad9371"
 
+profile_path = dirname(realpath(__file__)) + "/ad9371_5_profiles/"
+test_profiles = [join(profile_path, f) for f in listdir(profile_path)]
+
 params = [
     dict(   # One CW Tone, Manual
         ensm_mode="radio_on",
@@ -454,3 +457,16 @@ def test_ad9371_dds_gain_check_vary_power(
 @pytest.mark.parametrize("sfdr_min", [40])
 def test_ad9371_sfdr(test_sfdr, iio_uri, classname, channel, param_set, sfdr_min):
     test_sfdr(iio_uri, classname, channel, param_set, sfdr_min)
+
+
+#########################################
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("attr", ["profile"])
+@pytest.mark.parametrize(
+    "files", test_profiles,
+)
+def test_ad9371_profile_write(
+    test_attribute_write_only_str, iio_uri, classname, attr, files
+):
+    test_attribute_write_only_str(iio_uri, classname, attr, files)


### PR DESCRIPTION
# Description

Corrected the variable name obs_temp_comp_gain from obs_temp_comp_gain0


# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

* Pytest


**Test Configuration**:
* Hardware: ADRV9371-ZC706
* OS: ADI-Kuiper-Linux 2019R2 RC10

# Documentation

If this is a new feature or example please mention or link any documentation. All new hardware interface classes require documentation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
