### PR TITLE
Added patch for OBS channel support

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -37,6 +37,24 @@ def pytest_collection_modifyitems(items):
                     break
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--obs-enable",
+        action="store_true",
+        help="Run tests that use observation data paths",
+    )
+
+
+def pytest_runtest_setup(item):
+    # Handle observation based devices
+    obs = item.config.getoption("--obs-enable")
+    marks = [mark.name for mark in item.iter_markers()]
+    if not obs and "obs_required" in marks:
+        pytest.skip(
+            "Testing requiring observation disabled. Use --obs-enable flag to enable"
+        )
+
+
 #################################################
 def dev_interface(uri, classname, val, attr, tol):
     sdr = eval(classname + "(uri='" + uri + "')")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,7 +2,13 @@ import random
 import test.rf.spec as spec
 import time
 from test.attr_tests import *
-from test.common import dev_interface, pytest_collection_modifyitems, pytest_configure
+from test.common import (
+    dev_interface,
+    pytest_collection_modifyitems,
+    pytest_configure,
+    pytest_runtest_setup,
+    pytest_addoption,
+)
 from test.dma_tests import *
 from test.generics import iio_attribute_single_value
 from test.globals import *


### PR DESCRIPTION
Signed-off-by: Hannah Rosete <hannah.rosete@analog.com>

# Description

Added code to support the OBS channel when running pytest using added command-line arguments.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
