### PR TITLE
Added dds_two_tone test in test/dma_tests.py

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,10 +4,10 @@ import time
 from test.attr_tests import *
 from test.common import (
     dev_interface,
+    pytest_addoption,
     pytest_collection_modifyitems,
     pytest_configure,
     pytest_runtest_setup,
-    pytest_addoption,
 )
 from test.dma_tests import *
 from test.generics import iio_attribute_single_value
@@ -140,3 +140,8 @@ def test_attribute_write_only_str(request):
 @pytest.fixture()
 def test_dma_dac_zeros(request):
     yield dma_dac_zeros
+
+
+@pytest.fixture()
+def test_dds_two_tone(request):
+    yield dds_two_tone

--- a/test/dma_tests.py
+++ b/test/dma_tests.py
@@ -1,9 +1,11 @@
+import heapq
 import test.rf.spec as spec
 import time
 
 import adi
 import numpy as np
 import pytest
+from scipy import signal
 
 
 def dma_rx(uri, classname, channel):
@@ -282,7 +284,7 @@ def dds_two_tone(uri, classname, param_set, channel, frequency1, scale1, peak_mi
 
     """
     # See if we can tone using DMAs
-    sdr = eval(classname + "(uri='" + iio_uri + "')")
+    sdr = eval(classname + "(uri='" + uri + "')")
     # Set custom device parameters
     for p in param_set.keys():
         setattr(sdr, p, param_set[p])

--- a/test/dma_tests.py
+++ b/test/dma_tests.py
@@ -252,6 +252,93 @@ def dds_loopback(uri, classname, param_set, channel, frequency, scale, peak_min)
     assert tone_peaks[indx] > peak_min
 
 
+def dds_two_tone(uri, classname, param_set, channel, frequency1, scale1, peak_min1, frequency2, scale2, peak_min2):
+    """
+        dds_two_tone: Definition
+
+        parameters:
+            uri: type=string
+                URI of IIO context of target board/system
+            classname: type=string
+                Name of pyadi interface class which contain attribute
+            param_set: type=dict
+                Dictionary of attribute and values to be set before tone is
+                generated and received
+            channel: type=list
+                List of integers or list of list of integers of channels to
+                enable through tx_enabled_channels
+            frequency1: type=integer
+                Frequency in Hz of the first transmitted tone
+            scale1: type=float
+                Scale of the first DDS tone. Range [0,1]
+            peak_min1: type=float
+                Minimum acceptable value of maximum peak in dBFS of the received first tone
+            frequency2: type=integer
+                Frequency in Hz of the second transmitted tone
+            scale2: type=float
+                Scale of the second DDS tone. Range [0,1]
+            peak_min2: type=float
+                Minimum acceptable value of maximum peak in dBFS of the received second tone
+
+    """
+    # See if we can tone using DMAs
+    sdr = eval(classname + "(uri='" + iio_uri + "')")
+    # Set custom device parameters
+    for p in param_set.keys():
+        setattr(sdr, p, param_set[p])
+    # Set common buffer settings
+    sdr.tx_cyclic_buffer = True
+    N = 2 ** 14
+    # Create a sinewave waveform
+    if hasattr(sdr, "sample_rate"):
+        RXFS = int(sdr.sample_rate)
+    else:
+        RXFS = int(sdr.rx_sample_rate)
+
+    sdr.rx_enabled_channels = [channel]
+    sdr.rx_buffer_size = N * 2 * len(sdr.rx_enabled_channels)
+    sdr.dds_dual_tone(frequency1, scale1, frequency2, scale2, channel)
+
+    # Pass through SDR
+    try:
+        for _ in range(10):  # Wait
+            data = sdr.rx()
+    except Exception as e:
+        del sdr
+        raise Exception(e)
+    del sdr
+    tone_peaks, tone_freqs = spec.spec_est(data, fs=RXFS, ref=2 ** 15)
+    indx = heapq.nlargest(2, range(len(tone_peaks)), tone_peaks.__getitem__)
+    print("Peak 1: " + str(tone_peaks[indx[0]]) + " @ " + str(tone_freqs[indx[0]]))
+    print("Peak 2: " + str(tone_peaks[indx[1]]) + " @ " + str(tone_freqs[indx[1]]))
+
+    try:
+        if (abs(frequency1 - tone_freqs[indx[0]]) <= (frequency1 * 0.01)) and (
+            abs(frequency2 - tone_freqs[indx[1]]) <= (frequency2 * 0.01)
+        ):
+            diff1 = np.abs(tone_freqs[indx[0]] - frequency1)
+            diff2 = np.abs(tone_freqs[indx[1]] - frequency2)
+            # print(frequency1, frequency2)
+            # print(tone_freqs[indx[0]], tone_freqs[indx[1]])
+            # print(tone_peaks[indx[0]], tone_peaks[indx[1]])
+            # print(diff1, diff2)
+            assert (frequency1 * 0.01) > diff1
+            assert (frequency2 * 0.01) > diff2
+            assert tone_peaks[indx[0]] > peak_min1
+            assert tone_peaks[indx[1]] > peak_min2
+        elif (abs(frequency2 - tone_freqs[indx[0]]) <= (frequency2 * 0.01)) and (
+            abs(frequency1 - tone_freqs[indx[1]]) <= (frequency1 * 0.01)
+        ):
+            diff1 = np.abs(tone_freqs[indx[0]] - frequency2)
+            diff2 = np.abs(tone_freqs[indx[1]] - frequency1)
+            assert (frequency2 * 0.01) > diff1
+            assert (frequency1 * 0.01) > diff2
+            assert tone_peaks[indx[1]] > peak_min1
+            assert tone_peaks[indx[0]] > peak_min2
+    except Exception as e:
+        raise Exception(e)
+
+
 def nco_loopback(uri, classname, param_set, channel, frequency, peak_min):
     """ nco_loopback: TX/DAC Test tone loopback with connected loopback cables.
         This test requires a devices with TX and RX onboard where the transmit

--- a/test/dma_tests.py
+++ b/test/dma_tests.py
@@ -254,7 +254,7 @@ def dds_loopback(uri, classname, param_set, channel, frequency, scale, peak_min)
     assert tone_peaks[indx] > peak_min
 
 
-def dds_two_tone(uri, classname, param_set, channel, frequency1, scale1, peak_min1, frequency2, scale2, peak_min2):
+def dds_two_tone(uri, classname, channel, param_set, frequency1, scale1, peak_min1, frequency2, scale2, peak_min2):
     """
         dds_two_tone: Definition
 
@@ -314,31 +314,28 @@ def dds_two_tone(uri, classname, param_set, channel, frequency1, scale1, peak_mi
     print("Peak 1: " + str(tone_peaks[indx[0]]) + " @ " + str(tone_freqs[indx[0]]))
     print("Peak 2: " + str(tone_peaks[indx[1]]) + " @ " + str(tone_freqs[indx[1]]))
 
-    try:
-        if (abs(frequency1 - tone_freqs[indx[0]]) <= (frequency1 * 0.01)) and (
-            abs(frequency2 - tone_freqs[indx[1]]) <= (frequency2 * 0.01)
-        ):
-            diff1 = np.abs(tone_freqs[indx[0]] - frequency1)
-            diff2 = np.abs(tone_freqs[indx[1]] - frequency2)
-            # print(frequency1, frequency2)
-            # print(tone_freqs[indx[0]], tone_freqs[indx[1]])
-            # print(tone_peaks[indx[0]], tone_peaks[indx[1]])
-            # print(diff1, diff2)
-            assert (frequency1 * 0.01) > diff1
-            assert (frequency2 * 0.01) > diff2
-            assert tone_peaks[indx[0]] > peak_min1
-            assert tone_peaks[indx[1]] > peak_min2
-        elif (abs(frequency2 - tone_freqs[indx[0]]) <= (frequency2 * 0.01)) and (
-            abs(frequency1 - tone_freqs[indx[1]]) <= (frequency1 * 0.01)
-        ):
-            diff1 = np.abs(tone_freqs[indx[0]] - frequency2)
-            diff2 = np.abs(tone_freqs[indx[1]] - frequency1)
-            assert (frequency2 * 0.01) > diff1
-            assert (frequency1 * 0.01) > diff2
-            assert tone_peaks[indx[1]] > peak_min1
-            assert tone_peaks[indx[0]] > peak_min2
-    except Exception as e:
-        raise Exception(e)
+    if (abs(frequency1 - tone_freqs[indx[0]]) <= (frequency1 * 0.01)) and (
+        abs(frequency2 - tone_freqs[indx[1]]) <= (frequency2 * 0.01)
+    ):
+        diff1 = np.abs(tone_freqs[indx[0]] - frequency1)
+        diff2 = np.abs(tone_freqs[indx[1]] - frequency2)
+        # print(frequency1, frequency2)
+        # print(tone_freqs[indx[0]], tone_freqs[indx[1]])
+        # print(tone_peaks[indx[0]], tone_peaks[indx[1]])
+        # print(diff1, diff2)
+        assert (frequency1 * 0.01) > diff1
+        assert (frequency2 * 0.01) > diff2
+        assert tone_peaks[indx[0]] > peak_min1
+        assert tone_peaks[indx[1]] > peak_min2
+    elif (abs(frequency2 - tone_freqs[indx[0]]) <= (frequency2 * 0.01)) and (
+        abs(frequency1 - tone_freqs[indx[1]]) <= (frequency1 * 0.01)
+    ):
+        diff1 = np.abs(tone_freqs[indx[0]] - frequency2)
+        diff2 = np.abs(tone_freqs[indx[1]] - frequency1)
+        assert (frequency2 * 0.01) > diff1
+        assert (frequency1 * 0.01) > diff2
+        assert tone_peaks[indx[1]] > peak_min1
+        assert tone_peaks[indx[0]] > peak_min2
 
 
 def nco_loopback(uri, classname, param_set, channel, frequency, peak_min):

--- a/test/dma_tests.py
+++ b/test/dma_tests.py
@@ -256,7 +256,11 @@ def dds_loopback(uri, classname, param_set, channel, frequency, scale, peak_min)
 
 def dds_two_tone(uri, classname, channel, param_set, frequency1, scale1, peak_min1, frequency2, scale2, peak_min2):
     """
-        dds_two_tone: Definition
+        dds_two_tone: Test DDS loopback with connected loopback cables.
+        This test requires a devices with TX and RX onboard where the transmit
+        signal can be recovered. TX FPGA DDSs are used to generate two sinusoids
+        which are then estimated on the RX side. The receive tones must be within
+        1% of its respective expected frequency with a specified peak.
 
         parameters:
             uri: type=string

--- a/test/test_ad9371.py
+++ b/test/test_ad9371.py
@@ -1,13 +1,8 @@
-import heapq
-import test.rf.spec as spec
-import time
 from os import listdir
 from os.path import dirname, join, realpath
 
-import adi
-import numpy as np
 import pytest
-from scipy import signal
+
 
 hardware = "ad9371"
 classname = "adi.ad9371"


### PR DESCRIPTION
# Description

Added dds_two_tone test (alongside its required modules) in test/dma_tests.py that is initially coded inside test/test_ad9371.py.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Ran pytest on the specified setup below and compared the result with that of a manual test to the existing test case of the ADRV9371.

**Test Configuration**:
* Hardware: AD9371 + ZC706
* OS: ADI-Kuiper-Linux , 2019R2 RC10

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
