### PR TITLE
Added obs_required to the list of pytest markers

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -20,6 +20,10 @@ def pytest_configure(config):
     for k in keys:
         config.addinivalue_line("markers", k.replace("-", "_"))
 
+    # Add custom marks to ini for OBS channels
+    config.addinivalue_line(
+        "markers", "obs_required: mark tests that require observation data paths")
+
 
 def pytest_collection_modifyitems(items):
     # Map HDL project names to tests as markers


### PR DESCRIPTION
Signed-off-by: Hannah Rosete <hannah.rosete@analog.com>

# Description

Added code to include obs_required to the list of known pytest markers.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
