### PR TITLE
Added tests for setups with splitters between RX and ORX, changed the sfdr_min value, and little formatting changes

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -22,7 +22,8 @@ def pytest_configure(config):
 
     # Add custom marks to ini for OBS channels
     config.addinivalue_line(
-        "markers", "obs_required: mark tests that require observation data paths")
+        "markers", "obs_required: mark tests that require observation data paths"
+    )
 
 
 def pytest_collection_modifyitems(items):

--- a/test/dma_tests.py
+++ b/test/dma_tests.py
@@ -254,7 +254,18 @@ def dds_loopback(uri, classname, param_set, channel, frequency, scale, peak_min)
     assert tone_peaks[indx] > peak_min
 
 
-def dds_two_tone(uri, classname, channel, param_set, frequency1, scale1, peak_min1, frequency2, scale2, peak_min2):
+def dds_two_tone(
+    uri,
+    classname,
+    channel,
+    param_set,
+    frequency1,
+    scale1,
+    peak_min1,
+    frequency2,
+    scale2,
+    peak_min2,
+):
     """
         dds_two_tone: Test DDS loopback with connected loopback cables.
         This test requires a devices with TX and RX onboard where the transmit

--- a/test/test_ad9371.py
+++ b/test/test_ad9371.py
@@ -432,7 +432,7 @@ def test_ad9371_dds_gain_check_vary_power_with_obs(
         params["change_temp_gain_down"],
     ],
 )
-@pytest.mark.parametrize("sfdr_min", [40])
+@pytest.mark.parametrize("sfdr_min", [50])
 def test_ad9371_sfdr(test_sfdr, iio_uri, classname, channel, param_set, sfdr_min):
     test_sfdr(iio_uri, classname, channel, param_set, sfdr_min)
 

--- a/test/test_ad9371.py
+++ b/test/test_ad9371.py
@@ -309,7 +309,16 @@ def test_ad9371_two_tone_loopback(
     peak_min2,
 ):
     test_dds_two_tone(
-        iio_uri, classname, channel, param_set, frequency1, scale1, peak_min1, frequency2, scale2, peak_min2
+        iio_uri,
+        classname,
+        channel,
+        param_set,
+        frequency1,
+        scale1,
+        peak_min1,
+        frequency2,
+        scale2,
+        peak_min2,
     )
 
 
@@ -336,7 +345,16 @@ def test_ad9371_two_tone_loopback_with_obs(
     peak_min2,
 ):
     test_dds_two_tone(
-        iio_uri, classname, channel, param_set, frequency1, scale1, peak_min1, frequency2, scale2, peak_min2
+        iio_uri,
+        classname,
+        channel,
+        param_set,
+        frequency1,
+        scale1,
+        peak_min1,
+        frequency2,
+        scale2,
+        peak_min2,
     )
 
 

--- a/test/test_ad9371.py
+++ b/test/test_ad9371.py
@@ -3,7 +3,6 @@ from os.path import dirname, join, realpath
 
 import pytest
 
-
 hardware = "ad9371"
 classname = "adi.ad9371"
 
@@ -232,24 +231,48 @@ def test_ad9371_rx_data(test_dma_rx, iio_uri, classname, channel):
         (params["change_rf_gain_20dB_manual"], 2000000, 0.25, -9),
         (params["change_temp_gain_up"], 2000000, 0.25, -16),
         (params["change_temp_gain_down"], 2000000, 0.25, -22),
-        # peak_min when the ADRV9371 setup has a splitter between RX and ORX
-        # (params["one_cw_tone_manual"], 2000000, 0.5, -33),
-        # (params["one_cw_tone_manual"], 2000000, 0.12, -45),
-        # (params["one_cw_tone_manual"], 2000000, 0.25, -39),
-        # (params["one_cw_tone_auto"], 1000000, 0.12, -34.7),
-        # (params["one_cw_tone_auto"], 2000000, 0.12, -34.7),
-        # (params["one_cw_tone_auto"], 500000, 0.12, -34.7),
-        # (params["change_attenuation_5dB_manual"], 2000000, 0.25, -43.8),
-        # (params["change_attenuation_10dB_manual"], 2000000, 0.25, -48.75),
-        # (params["change_attenuation_0dB_auto"], 1000000, 0.12, -29),
-        # (params["change_attenuation_20dB_auto"], 1000000, 0.12, -44.7),
-        # (params["change_rf_gain_0dB_manual"], 2000000, 0.25, -49),
-        # (params["change_rf_gain_20dB_manual"], 2000000, 0.25, -29),
-        # (params["change_temp_gain_up"], 2000000, 0.25, -36),
-        # (params["change_temp_gain_down"], 2000000, 0.25, -42),
     ],
 )
 def test_ad9371_dds_loopback(
+    test_dds_loopback,
+    iio_uri,
+    classname,
+    param_set,
+    channel,
+    frequency,
+    scale,
+    peak_min,
+):
+    test_dds_loopback(
+        iio_uri, classname, param_set, channel, frequency, scale, peak_min
+    )
+
+
+########################################
+@pytest.mark.obs_required
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("channel", [0, 1])
+@pytest.mark.parametrize(
+    "param_set, frequency, scale, peak_min",
+    [
+        (params["one_cw_tone_manual"], 2000000, 0.5, -33),
+        (params["one_cw_tone_manual"], 2000000, 0.12, -45),
+        (params["one_cw_tone_manual"], 2000000, 0.25, -39),
+        (params["one_cw_tone_auto"], 1000000, 0.12, -34.7),
+        (params["one_cw_tone_auto"], 2000000, 0.12, -34.7),
+        (params["one_cw_tone_auto"], 500000, 0.12, -34.7),
+        (params["change_attenuation_5dB_manual"], 2000000, 0.25, -43.8),
+        (params["change_attenuation_10dB_manual"], 2000000, 0.25, -48.75),
+        (params["change_attenuation_0dB_auto"], 1000000, 0.12, -29),
+        (params["change_attenuation_20dB_auto"], 1000000, 0.12, -44.7),
+        (params["change_rf_gain_0dB_manual"], 2000000, 0.25, -49),
+        (params["change_rf_gain_20dB_manual"], 2000000, 0.25, -29),
+        (params["change_temp_gain_up"], 2000000, 0.25, -36),
+        (params["change_temp_gain_down"], 2000000, 0.25, -42),
+    ],
+)
+def test_ad9371_dds_loopback_with_obs(
     test_dds_loopback,
     iio_uri,
     classname,
@@ -273,6 +296,33 @@ def test_ad9371_dds_loopback(
     [(params["one_cw_tone_auto"], 1000000, 0.06, -21, 2000000, 0.12, -15)],
 )
 def test_ad9371_two_tone_loopback(
+    test_dds_two_tone,
+    iio_uri,
+    classname,
+    channel,
+    param_set,
+    frequency1,
+    scale1,
+    peak_min1,
+    frequency2,
+    scale2,
+    peak_min2,
+):
+    test_dds_two_tone(
+        iio_uri, classname, channel, param_set, frequency1, scale1, peak_min1, frequency2, scale2, peak_min2
+    )
+
+
+#########################################
+@pytest.mark.obs_required
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("channel", [0, 1])
+@pytest.mark.parametrize(
+    "param_set, frequency1, scale1, peak_min1, frequency2, scale2, peak_min2",
+    [(params["one_cw_tone_auto"], 1000000, 0.06, -41, 2000000, 0.12, -35)],
+)
+def test_ad9371_two_tone_loopback_with_obs(
     test_dds_two_tone,
     iio_uri,
     classname,
@@ -327,6 +377,43 @@ def test_ad9371_dds_gain_check_vary_power(
 
 
 #########################################
+@pytest.mark.obs_required
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("channel", [0, 1])
+@pytest.mark.parametrize(
+    "param_set, dds_scale, min_rssi, max_rssi",
+    [
+        (params["one_cw_tone_manual"], 0.5, 30, 31),
+        (params["one_cw_tone_manual"], 0.12, 42.5, 43.5),
+        (params["one_cw_tone_manual"], 0.25, 35.5, 36.5),
+        (params["one_cw_tone_auto"], 0.12, 32.5, 33.5),
+        (params["change_attenuation_5dB_manual"], 0.25, 41, 42),
+        (params["change_attenuation_10dB_manual"], 0.25, 44, 45),
+        (params["change_attenuation_0dB_auto"], 0.12, 22.75, 23.75),
+        (params["change_attenuation_20dB_auto"], 0.12, 42, 43),
+        (params["change_rf_gain_0dB_manual"], 0.25, 45.5, 46.5),
+        (params["change_rf_gain_20dB_manual"], 0.25, 26, 27),
+        (params["change_temp_gain_up"], 0.25, 35.75, 36.75),
+        (params["change_temp_gain_down"], 0.25, 35.75, 36.75),
+    ],
+)
+def test_ad9371_dds_gain_check_vary_power_with_obs(
+    test_gain_check,
+    iio_uri,
+    classname,
+    channel,
+    param_set,
+    dds_scale,
+    min_rssi,
+    max_rssi,
+):
+    test_gain_check(
+        iio_uri, classname, channel, param_set, dds_scale, min_rssi, max_rssi
+    )
+
+
+#########################################
 @pytest.mark.iio_hardware(hardware)
 @pytest.mark.parametrize("classname", [(classname)])
 @pytest.mark.parametrize("channel", [0, 1])
@@ -347,6 +434,33 @@ def test_ad9371_dds_gain_check_vary_power(
 )
 @pytest.mark.parametrize("sfdr_min", [40])
 def test_ad9371_sfdr(test_sfdr, iio_uri, classname, channel, param_set, sfdr_min):
+    test_sfdr(iio_uri, classname, channel, param_set, sfdr_min)
+
+
+#########################################
+@pytest.mark.obs_required
+@pytest.mark.iio_hardware(hardware)
+@pytest.mark.parametrize("classname", [(classname)])
+@pytest.mark.parametrize("channel", [0, 1])
+@pytest.mark.parametrize(
+    "param_set",
+    [
+        params["one_cw_tone_manual"],
+        params["one_cw_tone_auto"],
+        params["change_attenuation_5dB_manual"],
+        params["change_attenuation_10dB_manual"],
+        params["change_attenuation_0dB_auto"],
+        params["change_attenuation_20dB_auto"],
+        params["change_rf_gain_0dB_manual"],
+        params["change_rf_gain_20dB_manual"],
+        params["change_temp_gain_up"],
+        params["change_temp_gain_down"],
+    ],
+)
+@pytest.mark.parametrize("sfdr_min", [50])
+def test_ad9371_sfdr_with_obs(
+    test_sfdr, iio_uri, classname, channel, param_set, sfdr_min
+):
     test_sfdr(iio_uri, classname, channel, param_set, sfdr_min)
 
 


### PR DESCRIPTION
# Description

Added tests for setups with splitters between RX and ORX, changed the sfdr_min value to 50dB, and incorporated little formatting changes c/o pytest-black.

# How has this been tested?

Ran pytest on the specified setup below and compared the result with that of a manual test to the existing test case of the ADRV9371.

**Test Configuration**:
* Hardware: AD9371 + ZC706
* OS: ADI-Kuiper-Linux , 2019R2 RC10

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
