### PR TITLE
Added support for obs: ORX Sampling Rate

### DIFF
--- a/adi/ad9371.py
+++ b/adi/ad9371.py
@@ -233,6 +233,14 @@ class ad9371(rx_tx, context_manager):
         return self._get_iio_attr("voltage0", "sampling_frequency", False) / dec
 
     @property
+    def orx_sample_rate(self):
+        """orx_sample_rate: Sample rate ORX path in samples per second
+            This value will reflect the correct value when 8x decimator is enabled
+        """
+        dec = 8 if self.rx_enable_dec8 else 1
+        return self._get_iio_attr("voltage2", "sampling_frequency", False) / dec
+
+    @property
     def tx_sample_rate(self):
         """tx_sample_rate: Sample rate TX path in samples per second
             This value will reflect the correct value when 8x interpolator is enabled

--- a/test/test_ad9371.py
+++ b/test/test_ad9371.py
@@ -557,27 +557,29 @@ def test_ad9371_dds_loopback_with_10dB_splitter(
 @pytest.mark.obs_required
 @pytest.mark.iio_hardware(hardware)
 @pytest.mark.parametrize("classname", [(classname)])
-@pytest.mark.parametrize("channel", [0])
 @pytest.mark.parametrize(
-    "param_set, frequency, scale, peak_min, use_obs",
+    "channel, param_set",
     [
-        (params_obs["obs_orx1_manual"], 5000000, 0.25, -40.5, True),
-        (params_obs["obs_orx1_change_rf_gain_10dB"], 5000000, 0.25, -40.5, True),
-        (params_obs["obs_orx1_change_rf_gain_5dB"], 5000000, 0.25, -40.5, True),
-        (params_obs["obs_orx1_change_temp_gain_up"], 5000000, 0.25, -40.5, True),
-        (params_obs["obs_orx1_change_temp_gain_down"], 5000000, 0.25, -40.5, True),
-        (params_obs["obs_orx2_manual"], 5000000, 0.25, -41, True),
-        (params_obs["obs_orx2_change_rf_gain_10dB"], 5000000, 0.25, -40.5, True),
-        (params_obs["obs_orx2_change_rf_gain_5dB"], 5000000, 0.25, -40.5, True),
-        (params_obs["obs_orx2_change_temp_gain_up"], 5000000, 0.25, -40.5, True),
-        (params_obs["obs_orx2_change_temp_gain_down"], 5000000, 0.25, -40.5, True),
-        (params_obs["snf_orx1_manual"], 5000000, 0.25, -40.5, True),
-        (params_obs["snf_orx1_change_rf_gain_10dB"], 5000000, 0.25, -40.5, True),
-        (params_obs["snf_orx1_change_rf_gain_5dB"], 5000000, 0.25, -40.5, True),
-        (params_obs["snf_orx2_manual"], 5000000, 0.25, -40.5, True),
-        (params_obs["snf_orx2_change_rf_gain_10dB"], 5000000, 0.25, -40.5, True),
-        (params_obs["snf_orx2_change_rf_gain_5dB"], 5000000, 0.25, -40.5, True),
+        (0, params_obs["obs_orx1_manual"]),
+        (0, params_obs["obs_orx1_change_rf_gain_10dB"]),
+        (0, params_obs["obs_orx1_change_rf_gain_5dB"]),
+        (0, params_obs["obs_orx1_change_temp_gain_up"]),
+        (0, params_obs["obs_orx1_change_temp_gain_down"]),
+        (1, params_obs["obs_orx2_manual"]),
+        (1, params_obs["obs_orx2_change_rf_gain_10dB"]),
+        (1, params_obs["obs_orx2_change_rf_gain_5dB"]),
+        (1, params_obs["obs_orx2_change_temp_gain_up"]),
+        (1, params_obs["obs_orx2_change_temp_gain_down"]),
+        (0, params_obs["snf_orx1_manual"]),
+        (0, params_obs["snf_orx1_change_rf_gain_10dB"]),
+        (0, params_obs["snf_orx1_change_rf_gain_5dB"]),
+        (1, params_obs["snf_orx2_manual"]),
+        (1, params_obs["snf_orx2_change_rf_gain_10dB"]),
+        (1, params_obs["snf_orx2_change_rf_gain_5dB"]),
     ],
+)
+@pytest.mark.parametrize(
+    "frequency, scale, peak_min, use_obs", [(5000000, 0.25, -40.5, True)]
 )
 def test_ad9371_dds_loopback_for_obs(
     test_dds_loopback,


### PR DESCRIPTION
# Description

Mapped ORX Sampling Rate and Rearranged parametrization to dds_loopback test for obs

# How has this been tested?

Ran pytest on the specified setup below and compared the result with that of a manual test to the existing test case of the ADRV9371.

**Test Configuration**:
* Hardware: AD9371 + ZC706
* OS: ADI-Kuiper-Linux , 2019R2 RC10

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
